### PR TITLE
Refactor frontend message types

### DIFF
--- a/videochat/frontend/index.html
+++ b/videochat/frontend/index.html
@@ -17,46 +17,6 @@
     </style>
   </head>
   <body>
-    <!-- Visitor count display -->
-    <div id="visitor-count">0</div>
-    
-    <!-- The Yew app will mount to the document body automatically. -->
-    
-    <!-- Add the visitor counter script -->
-    <script>
-      (function () {
-        // Change the WebSocket URL as needed.
-        const wsUrl = `wss://${window.location.host}/visitors`;
-        const countElem = document.getElementById("visitor-count");
-        if (!countElem) {
-          console.error("No element with id 'visitor-count' found.");
-          return;
-        }
-        const ws = new WebSocket(wsUrl);
-
-        ws.onopen = function () {
-          console.log("Connected to visitor counter.");
-        };
-
-        ws.onmessage = function (event) {
-          try {
-            const data = JSON.parse(event.data);
-            if (data.visitorCount !== undefined) {
-              countElem.textContent = data.visitorCount;
-            }
-          } catch (err) {
-            console.error("Error parsing visitor count message:", err);
-          }
-        };
-
-        ws.onclose = function () {
-          console.log("Disconnected from visitor counter.");
-        };
-
-        window.addEventListener("beforeunload", function () {
-          ws.close();
-        });
-      })();
-    </script>
+  <!-- The Yew app will mount to the document body automatically. -->
   </body>
 </html>

--- a/videochat/frontend/src/lib.rs
+++ b/videochat/frontend/src/lib.rs
@@ -10,26 +10,14 @@ use yew::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use serde_json;
 use js_sys::{Array, Reflect};
-use serde::{Serialize, Deserialize};
+
 use std::rc::Rc;
 use std::cell::RefCell;
 mod visitor_counter;
+mod signaling;
 use visitor_counter::VisitorCounter;
 use web_sys::MediaTrackConstraints;
-#[derive(Serialize, Deserialize)]
-struct IceCandidateData {
-    candidate: String,
-    sdp_mid: Option<String>,
-    sdp_m_line_index: Option<u16>,
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "type", content = "data")]
-enum SignalMessage {
-    Offer(String),
-    Answer(String),
-    IceCandidate(IceCandidateData)
-}
+use signaling::{IceCandidateData, SignalMessage};
 
 #[function_component(App)]
 fn app() -> Html {


### PR DESCRIPTION
## Summary
- drop local definitions of signaling messages
- rely on the shared `signaling` module instead
- remove duplicate visitor-counter code from `index.html`

## Testing
- `cargo check --workspace` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6849cdc47a4883238d88d5ac28341f02